### PR TITLE
Bit Querying works

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -60,25 +60,34 @@ public:
 
     auto getBinCount() const
     {
+        assert(ibf_.bin_count() == bin_count_);
         return bin_count_;
     }
 
     uint32_t getBinSize() const
     {
+        assert(ibf_.bin_size() == bin_size_);
         return bin_size_;
     }
 
     uint8_t getHashCount() const
     {
+        assert(ibf_.hash_function_count() == hash_count_);
         return hash_count_;
     }
 
-   seqan3::interleaved_bloom_filter<seqan3::data_layout::uncompressed> getIBF()
-   {
-    return ibf_;
-   } 
+    // auto makeAgent()
+    // {
+    //     auto agent = ibf_.membership_agent();
+    //     return agent;
+    // }
 
-    void emplace(uint64_t val, uint8_t idx)
+    seqan3::interleaved_bloom_filter<seqan3::data_layout::uncompressed> getIBF()
+    {
+        return ibf_;
+    }
+
+    void emplace(uint64_t val, uint32_t idx)
     {
         ibf_.emplace(val, seqan3::bin_index{idx});
     }
@@ -86,7 +95,7 @@ public:
     template<class Archive>
     void serialize(Archive & archive)
     {
-        archive(bin_count_, bin_size_, hash_count_, k_);
+        archive(bin_count_, bin_size_, hash_count_, ibf_, k_, molecule_);
     }
 };
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,5 +1,4 @@
-#ifndef UTILS_H
-#define UTILS_H
+#pragma once
 
 #include <iostream>
 #include <string>
@@ -46,5 +45,3 @@ void matrixTotxt(const std::vector<std::vector<std::string>>& matrix, std::strin
 
 void matrixTXT(const std::vector<std::vector<std::string>>& matrix,
                 const std::vector<char>& alphabet);
-
-#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,7 +72,6 @@ void run_query(seqan3::argument_parser &parser)
     seqan3::debug_stream << "Reading Index from Disk... ";
     IndexStructure ibf;
     load_ibf(ibf, cmd_args.idx);
-    // seqan3::debug_stream << typeid(ibf).name() << std::endl;
     seqan3::debug_stream << "DONE" << std::endl;
 
     // Evaluate and search for Regular Expression
@@ -109,6 +108,7 @@ void run_query(seqan3::argument_parser &parser)
     // A vector to store kNFA paths as hashed constituent kmers eg one element would be. <78, 45, 83...> <--> AC, CG, GT
     auto hash_adaptor = seqan3::views::kmer_hash(seqan3::ungapped{qlength});
     std::vector<std::vector<std::pair<std::string, uint64_t>>> paths_vector;
+
     for(auto i : matrix)
     {
         std::vector<std::pair<std::string, uint64_t>> hash_vector;
@@ -121,11 +121,13 @@ void run_query(seqan3::argument_parser &parser)
         }
         paths_vector.push_back(hash_vector);
     }
+
     for (auto path : paths_vector)
     {
-        seqan3::debug_stream << collapse_kmers(qlength, path) << ":::";
+        //seqan3::debug_stream << collapse_kmers(qlength, path) << ":::";
         query_ibf(ibf, path);
     }
+    
     seqan3::debug_stream << "DONE" << std::endl;
 }
 


### PR DESCRIPTION
Perform logical operations on bitvectors instead of counting agent to find bins with hits.